### PR TITLE
Navigation: support route links and section scrolling, add AI Roadmap item

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -2,6 +2,20 @@ import { useState } from "react";
 import { Link } from "wouter";
 import { Menu, X } from "lucide-react";
 
+type SectionNavItem = {
+  label: string;
+  id: string;
+};
+
+type RouteNavItem = {
+  label: string;
+  href: string;
+};
+
+type NavItem = SectionNavItem | RouteNavItem;
+
+const isRouteItem = (item: NavItem): item is RouteNavItem => "href" in item;
+
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -11,11 +25,12 @@ export default function Navigation() {
     element?.scrollIntoView({ behavior: "smooth" });
   };
 
-  const navItems = [
+  const navItems: NavItem[] = [
     { label: "Home", id: "hero" },
     { label: "Experience", id: "experience" },
     { label: "Education", id: "education" },
     { label: "Certifications", id: "certifications" },
+    { label: "AI Roadmap", href: "/ai-learning-roadmap" },
   ];
 
   return (
@@ -32,13 +47,24 @@ export default function Navigation() {
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-8">
             {navItems.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => scrollToSection(item.id)}
-                className="text-muted-foreground hover:text-foreground transition-colors font-medium"
-              >
-                {item.label}
-              </button>
+              isRouteItem(item) ? (
+                <Link key={item.href} href={item.href}>
+                  <a
+                    onClick={() => setIsOpen(false)}
+                    className="text-muted-foreground hover:text-foreground transition-colors font-medium"
+                  >
+                    {item.label}
+                  </a>
+                </Link>
+              ) : (
+                <button
+                  key={item.id}
+                  onClick={() => scrollToSection(item.id)}
+                  className="text-muted-foreground hover:text-foreground transition-colors font-medium"
+                >
+                  {item.label}
+                </button>
+              )
             ))}
           </div>
 
@@ -55,13 +81,24 @@ export default function Navigation() {
         {isOpen && (
           <div className="md:hidden border-t border-border py-4 space-y-4">
             {navItems.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => scrollToSection(item.id)}
-                className="block w-full text-left px-4 py-2 text-muted-foreground hover:text-foreground hover:bg-accent/10 rounded-lg transition-colors font-medium"
-              >
-                {item.label}
-              </button>
+              isRouteItem(item) ? (
+                <Link key={item.href} href={item.href}>
+                  <a
+                    onClick={() => setIsOpen(false)}
+                    className="block w-full text-left px-4 py-2 text-muted-foreground hover:text-foreground hover:bg-accent/10 rounded-lg transition-colors font-medium"
+                  >
+                    {item.label}
+                  </a>
+                </Link>
+              ) : (
+                <button
+                  key={item.id}
+                  onClick={() => scrollToSection(item.id)}
+                  className="block w-full text-left px-4 py-2 text-muted-foreground hover:text-foreground hover:bg-accent/10 rounded-lg transition-colors font-medium"
+                >
+                  {item.label}
+                </button>
+              )
             ))}
           </div>
         )}


### PR DESCRIPTION
### Motivation
- Allow navigation items to be either page section links (smooth scroll) or normal route links so the navbar can link to internal sections and separate pages.
- Close the mobile menu when navigating to a route to improve UX on small screens.
- Add a dedicated "AI Roadmap" route to the navigation.

### Description
- Introduced TypeScript types `SectionNavItem`, `RouteNavItem`, and `NavItem` and a type guard `isRouteItem` to distinguish route vs section items.
- Typed the `navItems` array as `NavItem[]` and added the `{ label: "AI Roadmap", href: "/ai-learning-roadmap" }` route entry.
- Updated desktop and mobile render paths to conditionally render a `Link` (for route items) or a `button` that calls `scrollToSection` (for section items), and ensure route clicks close the mobile menu.

### Testing
- Ran TypeScript type checking (`tsc --noEmit`) which succeeded with no type errors.
- Built the client (`yarn build`) to validate the change compiles which succeeded.
- No new unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5cc1c33a0832db7686ef342767d11)